### PR TITLE
Add Combat Extended blaze bulb seeds

### DIFF
--- a/Defs_OnDemand/CombatExtended/Items_Seeds_CombatExtended.xml
+++ b/Defs_OnDemand/CombatExtended/Items_Seeds_CombatExtended.xml
@@ -1,0 +1,7 @@
+<Defs>
+  <SeedsPlease.SeedDef>
+    <defName>SeedPlantBlazebulb</defName>
+    <label>Blazebulb seeds</label>
+    <plant>PlantBlazebulb</plant>
+  </SeedsPlease.SeedDef>
+</Defs>

--- a/Patches/LoadOnDemand_Addons.xml
+++ b/Patches/LoadOnDemand_Addons.xml
@@ -2,7 +2,16 @@
 <Patch>
   
   <!-- Vegetable Garden Project -->
-  
+
+  <Operation Class="LoadOnDemand.PatchOperationLoadOnDemand">
+    <mods>
+      <li>Combat Extended</li>
+    </mods>
+    <folders>
+      <li>CombatExtended</li>
+    </folders>
+  </Operation>
+
   <Operation Class="LoadOnDemand.PatchOperationLoadOnDemand">
     <mods>
       <li>VGP Vegetable Garden</li>


### PR DESCRIPTION
This adds CE blaze bulb seeds items. No intermediary items or recipes are added - it didn't seem appropriate since the harvested item is basically a liquid chemical