### PR TITLE
Adding commonality tag to greenhouse traders.

### DIFF
--- a/Defs/TraderKindDefs/TraderGreenHouse.xml
+++ b/Defs/TraderKindDefs/TraderGreenHouse.xml
@@ -4,6 +4,7 @@
   <TraderKindDef>
     <defName>GreenHouseTrader</defName>
     <label>greenhouse trader</label>
+    <commonality>1</commonality>
     <orbital>true</orbital>
     <stockGenerators>
       <li Class="StockGenerator_SingleDef">
@@ -67,6 +68,7 @@
   <TraderKindDef>
     <defName>Caravan_GreenHouseTrader</defName>
     <label>greenhouse trader</label>
+    <commonality>1</commonality>
     <stockGenerators>
       <li Class="StockGenerator_SingleDef">
         <thingDef>Silver</thingDef>


### PR DESCRIPTION
Missing commonality tag causes yellow errors in dev console.