### PR TITLE
Unlock green house traders at comms console

### DIFF
--- a/Patches/Factions_Misc_Patch.xml
+++ b/Patches/Factions_Misc_Patch.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+    <!-- ========== Adding GreenHouseTrader to be avaliable from Trade Caravan request on comms console ========== -->
+
+    <Operation Class="PatchOperationSequence">
+        <success>Always</success>
+        <operations>
+            <li Class="PatchOperationAdd">
+                <xpath>/Defs/FactionDef[@Name="OutlanderFactionBase"]/caravanTraderKinds</xpath>
+                <value>
+                    <li>Caravan_GreenHouseTrader</li>
+                </value>
+            </li>
+        
+            <li Class="PatchOperationAdd">
+                <xpath>/Defs/FactionDef[@Name="TribeBase"]/caravanTraderKinds</xpath>
+                <value>
+                    <li>Caravan_GreenHouseTrader</li>
+                </value>
+            </li>
+        </operations>
+    </Operation>
+
+</Patch>


### PR DESCRIPTION
Makes green house traders to be available from Trade Caravan request on comms console.